### PR TITLE
adds enqueue_after_transaction_commit? for rails 7.2 compatibility

### DIFF
--- a/lib/lambdakiq/adapter.rb
+++ b/lib/lambdakiq/adapter.rb
@@ -10,6 +10,10 @@ module ActiveJob
         enqueue job, delay_seconds: delay_seconds(timestamp)
       end
 
+      def enqueue_after_transaction_commit?
+        true
+      end
+
       private
 
       def delay_seconds(timestamp)


### PR DESCRIPTION
Rails 7.2 has added the ability for jobs to enqueue after transaction commit, and for that to happen they have changed AbstractAdapter to include a new method `enqueue_after_transaction_commit?`.
For this reason, apps running rails 7.2+ and Lambdakiq are now breaking because of the missing method.
https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AbstractAdapter.html